### PR TITLE
refactor: use venv for installing extensions workaround

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -1,6 +1,11 @@
+extensions_venv := "/tmp/.venv-beyond-extensions"
+
 install-beyond-extensions:
-  pip install --upgrade gnome-extensions-cli
-  gext install replace-activities-label@leleat-on-github
-  gext install panel-corners@aunetx
+  python3 -m venv {{extensions_venv}}
+  {{extensions_venv}}/bin/pip install --upgrade gnome-extensions-cli
+  {{extensions_venv}}/bin/gext install replace-activities-label@leleat-on-github
+  {{extensions_venv}}/bin/gext install panel-corners@aunetx
+  rm -r {{extensions_venv}}
+
 yafti:
   yafti /etc/yafti.yml


### PR DESCRIPTION
by using that, you won't be installing "gext" on the system's python environment, thus (possibly) not breaking a lot of packages!