### PR TITLE
feat: Fix titlebar-font GSettings key name

### DIFF
--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -11,7 +11,7 @@ font-name="Inter 11"
 document-font-name="Inter 11"
 
 [org/gnome/desktop/wm/preferences]
-title-bar-font="Inter 11"
+titlebar-font="Inter 11"
 
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true


### PR DESCRIPTION
There is no hyphen in `titlebar-font`.

https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/blob/master/schemas/org.gnome.desktop.wm.preferences.gschema.xml.in#L187

(As an aside – maybe it would be useful for the ublue build process to validate schema overrides at build time?)