### PR TITLE
chore(ci): Create pull app config

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,6 @@
+version: "1"
+rules:
+  - base: main
+    upstream: ublue-os:main
+    mergeMethod: merge
+    mergeUnstable: false


### PR DESCRIPTION
Allows forks of this repo to use the [pull app](https://wei.github.io/pull/), useful for both contributing upstream and for creating custom images based on this one